### PR TITLE
ENG-48179: setting default scheme to passthrough

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"google.golang.org/grpc/resolver"
 	"strings"
 	"time"
 
@@ -224,6 +225,7 @@ func (gcs *ClientConfig) ToClientConn(ctx context.Context, host component.Host, 
 		return nil, err
 	}
 	opts = append(opts, extraOpts...)
+	resolver.SetDefaultScheme("passthrough")
 	return grpc.NewClient(gcs.sanitizedEndpoint(), opts...)
 }
 


### PR DESCRIPTION
With NewClient API usage, we are facing issues at few customers who have intermediate proxies between collector and platform. With NewClient API instead DialContext, DNS resolution happens on the client side while it should happen on proxy. Also, with SGProxy client does not get the correct certificate. Passthrough scheme was the prior default and prevents resolution to happen beforehand. This change can be removed once grpc fixes grpc/grpc-go#7556 and otel collector picks the fix

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
