### PR TITLE
ENG-48179: Revert NewClient api usage in configgrpc.

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -230,7 +230,7 @@ func (gcs *ClientConfig) ToClientConn(_ context.Context, host component.Host, se
 		return nil, err
 	}
 	opts = append(opts, extraOpts...)
-	return grpc.NewClient(gcs.sanitizedEndpoint(), opts...)
+	return grpc.DialContext(ctx, gcs.sanitizedEndpoint(), opts...)
 }
 
 func (gcs *ClientConfig) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {


### PR DESCRIPTION
With NewClient API usage, we are facing issues at few customers who have intermediate proxies between collector and platform. With NewClient API instead DialContext, DNS resolution happens on the client side while it should happen on proxy. Also, with SGProxy client does not get the correct certificate. can be changed once grpc fixes https://github.com/grpc/grpc-go/issues/7556 and otel collector picks the fix

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
